### PR TITLE
termux-change-repo: make it possible to select a single mirror again

### DIFF
--- a/mirrors/russia/mirror.mephi.ru
+++ b/mirrors/russia/mirror.mephi.ru
@@ -1,5 +1,5 @@
 # This file is sourced by pkg
-# Mirrors by National Research Nuclear University - Moscow Engineering Physics Institute
+# Mirrors by National Research Nuclear University MEPhI
 WEIGHT=1
 MAIN="http://mirror.mephi.ru/termux/termux-main"
 ROOT="http://mirror.mephi.ru/termux/termux-root"

--- a/scripts/pkg.in
+++ b/scripts/pkg.in
@@ -267,6 +267,11 @@ select_mirror() {
 				echo "deb $ROOT root stable" > @TERMUX_PREFIX@/etc/apt/sources.list.d/root.list
 			fi
 		)
+	else
+		# Should not happen unless there is some issue with
+		# the script, or the mirror files
+		echo "Error: None of the mirrors are accessible"
+		exit 1
 	fi
 }
 

--- a/scripts/pkg.in
+++ b/scripts/pkg.in
@@ -108,18 +108,18 @@ select_mirror() {
 
 	if [ -d "@TERMUX_PREFIX@/etc/termux/chosen_mirrors" ]; then
 		# Mirror group selected
-		mirrors=($(find @TERMUX_PREFIX@/etc/termux/chosen_mirrors/ -type f ! -name "*\.dpkg-old" ! -name "*~"))
+		mirrors=($(find @TERMUX_PREFIX@/etc/termux/chosen_mirrors/ -type f ! -name "*\.dpkg-old" ! -name "*\.dpkg-new" ! -name "*~"))
 	elif [ -f "@TERMUX_PREFIX@/etc/termux/chosen_mirrors" ]; then
 		# Single mirror selected
 		mirrors=("$(realpath @TERMUX_PREFIX@/etc/termux/chosen_mirrors)")
 	elif [ -L "@TERMUX_PREFIX@/etc/termux/chosen_mirrors" ]; then
 		# Broken symlink, use all mirrors
 		mirrors=("@TERMUX_PREFIX@/etc/termux/mirrors/default")
-		mirrors+=($(find @TERMUX_PREFIX@/etc/termux/mirrors/{asia,china,europe,north_america,russia}/ -type f ! -name "*\.dpkg-old" ! -name "*~"))
+		mirrors+=($(find @TERMUX_PREFIX@/etc/termux/mirrors/{asia,china,europe,north_america,russia}/ -type f ! -name "*\.dpkg-old" ! -name "*\.dpkg-new" ! -name "*~"))
 	else
 		echo "No mirror or mirror group selected. You might want to select one by running 'termux-change-repo'"
 		mirrors=("@TERMUX_PREFIX@/etc/termux/mirrors/default")
-		mirrors+=($(find @TERMUX_PREFIX@/etc/termux/mirrors/{asia,china,europe,north_america,russia}/ -type f ! -name "*\.dpkg-old" ! -name "*~"))
+		mirrors+=($(find @TERMUX_PREFIX@/etc/termux/mirrors/{asia,china,europe,north_america,russia}/ -type f ! -name "*\.dpkg-old" ! -name "*\.dpkg-new" ! -name "*~"))
 	fi
 
 	local current_mirror

--- a/scripts/pkg.in
+++ b/scripts/pkg.in
@@ -96,6 +96,10 @@ get_mirror_url() {
 
 get_mirror_weight() {
 	source "$1"
+	if [[ ! "$WEIGHT" =~ ^[0-9]+$ ]]; then
+		echo "[!] invalid weight in mirror $1" > /dev/stderr
+		exit
+	fi
 	echo $WEIGHT
 }
 

--- a/scripts/pkg.in
+++ b/scripts/pkg.in
@@ -103,13 +103,17 @@ select_mirror() {
 	local default_repo="@TERMUX_PREFIX@/etc/termux/mirrors/default"
 
 	if [ -d "@TERMUX_PREFIX@/etc/termux/chosen_mirrors" ]; then
+		# Mirror group selected
 		mirrors=($(find @TERMUX_PREFIX@/etc/termux/chosen_mirrors/ -type f ! -name "*\.dpkg-old" ! -name "*~"))
+	elif [ -f "@TERMUX_PREFIX@/etc/termux/chosen_mirrors" ]; then
+		# Single mirror selected
+		mirrors=("$(realpath @TERMUX_PREFIX@/etc/termux/chosen_mirrors)")
 	elif [ -L "@TERMUX_PREFIX@/etc/termux/chosen_mirrors" ]; then
 		# Broken symlink, use all mirrors
 		mirrors=("@TERMUX_PREFIX@/etc/termux/mirrors/default")
 		mirrors+=($(find @TERMUX_PREFIX@/etc/termux/mirrors/{asia,china,europe,north_america,russia}/ -type f ! -name "*\.dpkg-old" ! -name "*~"))
 	else
-		echo "No group of mirrors selected. You might want to select a group by running 'termux-change-repo'"
+		echo "No mirror or mirror group selected. You might want to select one by running 'termux-change-repo'"
 		mirrors=("@TERMUX_PREFIX@/etc/termux/mirrors/default")
 		mirrors+=($(find @TERMUX_PREFIX@/etc/termux/mirrors/{asia,china,europe,north_america,russia}/ -type f ! -name "*\.dpkg-old" ! -name "*~"))
 	fi

--- a/scripts/pkg.in
+++ b/scripts/pkg.in
@@ -4,6 +4,8 @@ set -eu
 # Setup TERMUX_APP_PACKAGE_MANAGER
 source "@TERMUX_PREFIX@/bin/termux-setup-package-manager" || exit 1
 
+MIRROR_BASE_DIR="@TERMUX_PREFIX@/etc/termux/mirrors"
+
 show_help() {
 	local cache_size
 	local cache_dir=""
@@ -104,7 +106,7 @@ get_mirror_weight() {
 }
 
 select_mirror() {
-	local default_repo="@TERMUX_PREFIX@/etc/termux/mirrors/default"
+	local default_repo="${MIRROR_BASE_DIR}/default"
 
 	if [ -d "@TERMUX_PREFIX@/etc/termux/chosen_mirrors" ]; then
 		# Mirror group selected
@@ -114,12 +116,12 @@ select_mirror() {
 		mirrors=("$(realpath @TERMUX_PREFIX@/etc/termux/chosen_mirrors)")
 	elif [ -L "@TERMUX_PREFIX@/etc/termux/chosen_mirrors" ]; then
 		# Broken symlink, use all mirrors
-		mirrors=("@TERMUX_PREFIX@/etc/termux/mirrors/default")
-		mirrors+=($(find @TERMUX_PREFIX@/etc/termux/mirrors/{asia,china,europe,north_america,russia}/ -type f ! -name "*\.dpkg-old" ! -name "*\.dpkg-new" ! -name "*~"))
+		mirrors=("${MIRROR_BASE_DIR}/default")
+		mirrors+=($(find ${MIRROR_BASE_DIR}/{asia,china,europe,north_america,russia}/ -type f ! -name "*\.dpkg-old" ! -name "*\.dpkg-new" ! -name "*~"))
 	else
 		echo "No mirror or mirror group selected. You might want to select one by running 'termux-change-repo'"
-		mirrors=("@TERMUX_PREFIX@/etc/termux/mirrors/default")
-		mirrors+=($(find @TERMUX_PREFIX@/etc/termux/mirrors/{asia,china,europe,north_america,russia}/ -type f ! -name "*\.dpkg-old" ! -name "*\.dpkg-new" ! -name "*~"))
+		mirrors=("${MIRROR_BASE_DIR}/default")
+		mirrors+=($(find ${MIRROR_BASE_DIR}/{asia,china,europe,north_america,russia}/ -type f ! -name "*\.dpkg-old" ! -name "*\.dpkg-new" ! -name "*~"))
 	fi
 
 	local current_mirror

--- a/scripts/termux-change-repo.in
+++ b/scripts/termux-change-repo.in
@@ -130,6 +130,17 @@ select_individual_mirror() {
     rm "$TEMPFILE"
 }
 
+usage() {
+   echo "Usage: termux-change-repo"
+   echo ""
+   echo "termux-change-repo is a utility used to simplify which mirror(s)"
+   echo "pkg (our apt wrapper) should use."
+}
+
+if [ $# -gt 0 ]; then
+    usage
+fi
+
 if ! command -v apt 1>/dev/null; then
     echo "Error: changing mirrors can't execute because apt is not installed."
     exit 1

--- a/scripts/termux-change-repo.in
+++ b/scripts/termux-change-repo.in
@@ -142,7 +142,7 @@ if [ $# -gt 0 ]; then
 fi
 
 if ! command -v apt 1>/dev/null; then
-    echo "Error: changing mirrors can't execute because apt is not installed."
+    echo "Error: Cannot change mirrors since apt is not installed." > /dev/stderr
     exit 1
 fi
 
@@ -159,7 +159,7 @@ MODES+=("Mirror group" "Rotate between several mirrors (recommended)" "on")
 MODES+=("Single mirror" "Choose a single mirror to use" "off")
 dialog \
     --title "termux-change-repo" --clear \
-    --radiolist "Do you want to select a mirror group or a single mirror?" 0 0 0 \
+    --radiolist "Do you want to choose a mirror group or a single mirror? Select with space." 0 0 0 \
     "${MODES[@]}" --and-widget \
     2> "$TEMPFILE"
 retval=$?

--- a/scripts/termux-change-repo.in
+++ b/scripts/termux-change-repo.in
@@ -3,6 +3,8 @@
 # Setup TERMUX_APP_PACKAGE_MANAGER
 source "@TERMUX_PREFIX@/bin/termux-setup-package-manager" || exit 1
 
+MIRROR_BASE_DIR="@TERMUX_PREFIX@/etc/termux/mirrors"
+
 if [ "$1" == "--help" ] || [ "$1" == "-help" ]; then
     echo "Script for choosing a group of mirrors to use."
     echo "All mirrors are listed at"
@@ -19,34 +21,113 @@ unlink_and_link() {
 }
 
 select_repository_group() {
-    if [ "$1" == "Mirrors in Asia" ]; then
+    MIRRORS=()
+    MIRRORS+=("All mirrors" "All in the entire world" "on")
+    MIRRORS+=("Mirrors in Asia" "All in Asia (excl. China and Russia)" "off")
+    MIRRORS+=("Mirrors in China" "All in China" "off")
+    MIRRORS+=("Mirrors in Europe" "All in Europe" "off")
+    MIRRORS+=("Mirrors in North America" "All in North America" "off")
+    MIRRORS+=("Mirrors in Russia" "All in Russia" "off")
+
+    local TEMPFILE="$(mktemp @TERMUX_PREFIX@/tmp/mirror.XXXXXX)"
+    dialog \
+        --title "termux-change-repo" --clear \
+        --radiolist "Which group of mirrors do you want to use? Select with space." 0 0 0 \
+        "${MIRRORS[@]}" --and-widget \
+        2> "$TEMPFILE"
+    retval=$?
+    clear
+
+    case $retval in
+        1)
+            # Cancel pressed
+            exit
+            ;;
+        255)
+            # Esc pressed
+            exit
+            ;;
+    esac
+
+    mirror_group="$(cat "$TEMPFILE")"
+    rm "$TEMPFILE"
+
+    if [ "$mirror_group" == "Mirrors in Asia" ]; then
         echo "[*] Mirrors in Asia (excl. China and Russia) selected"
-        unlink_and_link @TERMUX_PREFIX@/etc/termux/mirrors/asia
+        unlink_and_link ${MIRROR_BASE_DIR}/asia
 
-    elif [ "$1" == "Mirrors in China" ]; then
+    elif [ "$mirror_group" == "Mirrors in China" ]; then
         echo "[*] Mirrors in China selected"
-        unlink_and_link @TERMUX_PREFIX@/etc/termux/mirrors/china
+        unlink_and_link ${MIRROR_BASE_DIR}/china
 
-    elif [ "$1" == "Mirrors in Europe" ]; then
+    elif [ "$mirror_group" == "Mirrors in Europe" ]; then
         echo "[*] Mirrors in Europe selected"
-        unlink_and_link @TERMUX_PREFIX@/etc/termux/mirrors/europe
+        unlink_and_link ${MIRROR_BASE_DIR}/europe
 
-    elif [ "$1" == "Mirrors in North America" ]; then
+    elif [ "$mirror_group" == "Mirrors in North America" ]; then
         echo "[*] Mirrors in North America selected"
-        unlink_and_link @TERMUX_PREFIX@/etc/termux/mirrors/north_america
+        unlink_and_link ${MIRROR_BASE_DIR}/north_america
 
-    elif [ "$1" == "Mirrors in Russia" ]; then
+    elif [ "$mirror_group" == "Mirrors in Russia" ]; then
         echo "[*] Mirrors in Russia selected"
-        unlink_and_link @TERMUX_PREFIX@/etc/termux/mirrors/russia
+        unlink_and_link ${MIRROR_BASE_DIR}/russia
 
-    elif [ "$1" == "All mirrors" ]; then
+    elif [ "$mirror_group" == "All mirrors" ]; then
         echo "[*] All mirrors selected"
-        unlink_and_link @TERMUX_PREFIX@/etc/termux/mirrors/all
+        unlink_and_link ${MIRROR_BASE_DIR}/all
 
     else
         echo "[!] Error: unknown mirror group: '$1'. Exiting"
         exit 1
     fi
+}
+
+get_mirror_url() {
+    basename "$1"
+}
+
+get_mirror_description() {
+    head -n 2 "$1" | tail -n 1 | cut -d" " -f2-
+}
+
+select_individual_mirror() {
+    mirrors=($(find ${MIRROR_BASE_DIR}/{asia,china,europe,north_america,russia}/ -type f ! -name "*\.dpkg-old" ! -name "*~"))
+
+    # Choose default mirror per default
+    MIRRORS=("$(get_mirror_url "${MIRROR_BASE_DIR}/default")" "$(get_mirror_description "${MIRROR_BASE_DIR}/default")" "on")
+    # Special handling of packages.termux.dev mirror to put it on top:
+    MIRRORS+=("$(get_mirror_url "${MIRROR_BASE_DIR}/north_america/packages.termux.dev")" "$(get_mirror_description "${MIRROR_BASE_DIR}/north_america/packages.termux.dev")" "off")
+    for mirror in ${mirrors[@]}; do
+        if [ "$mirror" != "packages.termux.dev" ]; then
+            MIRRORS+=("$(get_mirror_url "$mirror")" "$(get_mirror_description "$mirror")" "off")
+        fi
+    done
+
+    local TEMPFILE="$(mktemp @TERMUX_PREFIX@/tmp/mirror.XXXXXX)"
+    dialog \
+        --title "termux-change-repo" --clear \
+        --radiolist "Which mirror do you want to use? Select with space." 0 0 0 \
+        "${MIRRORS[@]}" --and-widget \
+        2> "$TEMPFILE"
+    retval=$?
+    clear
+
+    case $retval in
+        1)
+            # Cancel pressed
+            exit
+            ;;
+        255)
+            # Esc pressed
+            exit
+            ;;
+    esac
+
+    mirror="$(cat "$TEMPFILE")"
+
+    echo "[*] Mirror $(get_mirror_url "$mirror") selected"
+    unlink_and_link "$(find ${MIRROR_BASE_DIR} -name $mirror)"
+    rm "$TEMPFILE"
 }
 
 if ! command -v apt 1>/dev/null; then
@@ -60,27 +141,29 @@ if [ "$TERMUX_APP_PACKAGE_MANAGER" = "pacman" ]; then
     [[ ${REPLY} =~ ^[Nn]$ ]] && exit
 fi
 
-TEMPFILE="$(mktemp @TERMUX_PREFIX@/tmp/mirror.XXXXXX)"
+TEMPFILE="$(mktemp @TERMUX_PREFIX@/tmp/termux-change-repo.XXXXXX)"
 
-MIRRORS=()
-MIRRORS+=("All mirrors" "All in the entire world" "on")
-MIRRORS+=("Mirrors in Asia" "All in Asia (excl. China and Russia)" "off")
-MIRRORS+=("Mirrors in China" "All in China" "off")
-MIRRORS+=("Mirrors in Europe" "All in Europe" "off")
-MIRRORS+=("Mirrors in North America" "All in North America" "off")
-MIRRORS+=("Mirrors in Russia" "All in Russia" "off")
-
+MODES=()
+MODES+=("Mirror group" "Rotate between several mirrors (recommended)" "on")
+MODES+=("Single mirror" "Choose a single mirror to use" "off")
 dialog \
     --title "termux-change-repo" --clear \
-    --radiolist "Which group of mirrors do you want to use? Select with space." 0 0 0 \
-    "${MIRRORS[@]}" --and-widget \
+    --radiolist "Do you want to select a mirror group or a single mirror?" 0 0 0 \
+    "${MODES[@]}" --and-widget \
     2> "$TEMPFILE"
 retval=$?
 clear
 
 case $retval in
     0)
-        select_repository_group "$(cat $TEMPFILE)"
+        case "$(cat $TEMPFILE)" in
+        "Mirror group")
+            select_repository_group
+            ;;
+        "Single mirror")
+            select_individual_mirror
+            ;;
+        esac
         ;;
     1)
         # Cancel pressed

--- a/scripts/termux-change-repo.in
+++ b/scripts/termux-change-repo.in
@@ -91,7 +91,7 @@ get_mirror_description() {
 }
 
 select_individual_mirror() {
-    mirrors=($(find ${MIRROR_BASE_DIR}/{asia,china,europe,north_america,russia}/ -type f ! -name "*\.dpkg-old" ! -name "*~"))
+    mirrors=($(find ${MIRROR_BASE_DIR}/{asia,china,europe,north_america,russia}/ -type f ! -name "*\.dpkg-old" ! -name "*\.dpkg-new" ! -name "*~"))
 
     # Choose default mirror per default
     MIRRORS=("$(get_mirror_url "${MIRROR_BASE_DIR}/default")" "$(get_mirror_description "${MIRROR_BASE_DIR}/default")" "on")


### PR DESCRIPTION
And verify that mirror weight is valid. 

We discussed that this functionality should be re-added in a couple of PRs/issues that I can't find, so ping @2096779623 and @agnostic-apollo, I remember that you were participating in the discussion.

Here are screenshots of what the two screens look like:

![termux-change-repo-1](https://user-images.githubusercontent.com/18900601/181936266-eb67ddc9-21ef-45ba-821a-eacbde299d79.png)

![termux-change-repo-2](https://user-images.githubusercontent.com/18900601/181936265-fd9663ae-945e-4924-9d69-5c070500cbb1.png)

If someone wants to try this out you can do it by running something like this in termux:

```
git clone https://github.com/termux/termux-tools -b pkg_and_termux-change-repo-updates
cd termux-tools
autoreconf -vfi
mkdir build && cd build
../configure --prefix $PREFIX
make
make install
```

--- 

Some things that can be improved includes:

* Creating the menu for selecting a single mirror is a bit slow, might be nice to decrease the overhead there somehow
* There's quite a lot of text on single-mirror selection page, probably looks horrible on small screens
