### PR TITLE
scripts: add option to suppress read failures for termux-backup

### DIFF
--- a/scripts/termux-backup.in
+++ b/scripts/termux-backup.in
@@ -47,6 +47,7 @@ show_usage() {
 	msg "Options:"
 	msg
 	msg " -h, --help             Show this information."
+	msg " -f, --force            Force write operations."
 	msg " --ignore-read-failure  Suppress read permission denials."
 	msg
 	msg "Backup is performed as TAR archive. Compression is determined"
@@ -69,12 +70,16 @@ fi
 
 BACKUP_FILE_PATH=
 TAR_EXTRA_OPTS=
+FORCE_WRITE=false
 while (($# >= 1)); do
 	case "$1" in
 		--) shift 1; break;;
 		-\?|-h|--help|--usage)
 			show_usage
 			exit 0
+			;;
+		-f|--force)
+			FORCE_WRITE=true
 			;;
 		--ignore-read-failure)
 			TAR_EXTRA_OPTS="--ignore-failed-read --warning=no-failed-read"
@@ -111,9 +116,9 @@ done
 
 if [ "$BACKUP_FILE_PATH" != "-" ]; then
 	TAR_EXTRA_OPTS="$TAR_EXTRA_OPTS --auto-compress"
-	if [ -e "$BACKUP_FILE_PATH" ]; then
+	if [ -e "$BACKUP_FILE_PATH" ] && ! $FORCE_WRITE; then
 		msg
-		msg "[!] Refusing to overwrite already existing file '$BACKUP_FILE_PATH'."
+		msg "[!] Refusing to overwrite existing file without --force option: '$BACKUP_FILE_PATH'."
 		msg
 		exit 1
 	fi

--- a/scripts/termux-backup.in
+++ b/scripts/termux-backup.in
@@ -117,6 +117,13 @@ if [ "$BACKUP_FILE_PATH" != "-" ]; then
 		msg
 		exit 1
 	fi
+else
+	if [ -t 1 ]; then
+		msg
+		msg "[!] Refusing to write archive data to console."
+		msg
+		exit 1
+	fi
 fi
 
 msg "Backing up installed packages..."

--- a/scripts/termux-backup.in
+++ b/scripts/termux-backup.in
@@ -39,10 +39,15 @@ msg() {
 
 show_usage() {
 	msg
-	msg "Usage: termux-backup [output file]"
+	msg "Usage: termux-backup [options] [output file]"
 	msg
 	msg "Script for backing up Termux installation directory, \$PREFIX."
 	msg "It WILL NOT backup your home directory."
+	msg
+	msg "Options:"
+	msg
+	msg " -h, --help             Show this information."
+	msg " --ignore-read-failure  Suppress read permission denials."
 	msg
 	msg "Backup is performed as TAR archive. Compression is determined"
 	msg "by output file extension. If file name is '-', then tarball is"
@@ -50,44 +55,70 @@ show_usage() {
 	msg
 }
 
-if [ $# -lt 1 ]; then
-	msg
-	msg "[!] Output file path is not specified."
-	show_usage
-	exit 1
-fi
-
-if [ $# -gt 1 ]; then
-	shift 1
-	msg
-	msg "[!] Got extra arguments: $*"
-	show_usage
-	exit 1
-fi
-
 if [ ! -d "$PREFIX" ]; then
 	msg "[!] $PREFIX: directory does not exist."
 	exit 1
 fi
 
-case "$1" in
-	-\?|-h|--help|--usage) show_usage; exit 0;;
-	*) BACKUP_FILE_PATH=$1;;
-esac
+if [ $# -lt 1 ]; then
+	msg
+	msg "[!] Not enough arguments."
+	show_usage
+	exit 1
+fi
+
+BACKUP_FILE_PATH=
+TAR_EXTRA_OPTS=
+while (($# >= 1)); do
+	case "$1" in
+		--) shift 1; break;;
+		-\?|-h|--help|--usage)
+			show_usage
+			exit 0
+			;;
+		--ignore-read-failure)
+			TAR_EXTRA_OPTS="--ignore-failed-read --warning=no-failed-read"
+			;;
+		*)
+			if [ -z "$1" ]; then
+				msg
+				msg "[!] Backup file path should not be an empty string."
+				show_usage
+				exit 1
+			fi
+
+			# Filter all previously unrecognized options except '-', which is
+			# a valid backup output specification.
+			if [[ $1 =~ ^-.+ ]]; then
+				msg
+				msg "[!] Unknown option passed: ${1}"
+				show_usage
+				exit 1
+			fi
+
+			if [ -z "$BACKUP_FILE_PATH" ]; then
+				BACKUP_FILE_PATH=$1
+			else
+				msg
+				msg "[!] Redundant backup file path specified: ${1}"
+				show_usage
+				exit 1
+			fi
+			;;
+	esac
+	shift 1
+done
 
 if [ "$BACKUP_FILE_PATH" != "-" ]; then
-	CAN_AUTOCOMPRESS=yes
+	TAR_EXTRA_OPTS="$TAR_EXTRA_OPTS --auto-compress"
 	if [ -e "$BACKUP_FILE_PATH" ]; then
 		msg
 		msg "[!] Refusing to overwrite already existing file '$BACKUP_FILE_PATH'."
 		msg
 		exit 1
 	fi
-else
-	CAN_AUTOCOMPRESS=
 fi
 
 msg "Backing up installed packages..."
-tar --warning=no-file-ignored -f "$BACKUP_FILE_PATH" \
-	-c ${CAN_AUTOCOMPRESS+--auto-compress} \
-	-C "@TERMUX_BASE_DIR@" ./usr
+tar --warning=no-file-ignored $TAR_EXTRA_OPTS -c \
+	-f "$BACKUP_FILE_PATH" -C "@TERMUX_BASE_DIR@" ./usr


### PR DESCRIPTION
In certain cases $PREFIX may contain files that can't be read, but it is acceptable to drop them from backup. The newly added option allows to suppress read permission errors reported by tar.

Also add option `--force` which allows to overwrite existing archive.