### PR TITLE
Remove packages.termux.dev mirrors

### DIFF
--- a/mirrors/Makefile.am
+++ b/mirrors/Makefile.am
@@ -9,19 +9,18 @@ mirrors.cbrx.io packages.nscdn.top
 pkgdata_CHINA_MIRRORS = mirrors.tuna.tsinghua.edu.cn		\
 mirror.iscas.ac.cn mirrors.nju.edu.cn mirrors.pku.edu.cn	\
 mirrors.ustc.edu.cn mirrors.hit.edu.cn mirrors.bfsu.edu.cn	\
-mirrors.aliyun.com mirrors.cqupt.edu.cn mirrors.dgut.edu.cn \
-mirror.nyist.edu.cn mirrors.njupt.edu.cn mirrors.sau.edu.cn \
+mirrors.aliyun.com mirrors.cqupt.edu.cn mirrors.dgut.edu.cn	\
+mirror.nyist.edu.cn mirrors.njupt.edu.cn mirrors.sau.edu.cn	\
 mirrors.scau.edu.cn mirrors.sdu.edu.cn mirrors.sustech.edu.cn
 
 # Mirrors in Europe
-pkgdata_EUROPE_MIRRORS = grimler.se termux.librehat.com mirror.mwt.me	\
-termux.mentality.rip mirrors.sahilister.in cdn.lumito.net \
+pkgdata_EUROPE_MIRRORS = termux.librehat.com mirror.mwt.me	\
+termux.mentality.rip mirrors.sahilister.in cdn.lumito.net	\
 termux.astra.in.ua
 
 # Mirrors in North America
-pkgdata_NORTH_AMERICA_MIRRORS = packages.termux.dev			\
-plug-mirror.rcac.purdue.edu dl.kcubeterm.com mirrors.utermux.dev	\
-mirror.mwt.me
+pkgdata_NORTH_AMERICA_MIRRORS = plug-mirror.rcac.purdue.edu	\
+dl.kcubeterm.com mirrors.utermux.dev mirror.mwt.me
 
 # Mirrors in Russia
 pkgdata_RUSSIA_MIRRORS = mirror.mephi.ru mirror.surf

--- a/mirrors/default
+++ b/mirrors/default
@@ -1,6 +1,6 @@
 # This file is sourced by pkg
-# Cached (by cloudflare) variant of packages.termux.dev
+# Mirror by grimler, hosted in the Netherlands
 WEIGHT=10
-MAIN="https://packages-cf.termux.dev/apt/termux-main"
-ROOT="https://packages-cf.termux.dev/apt/termux-root"
-X11="https://packages-cf.termux.dev/apt/termux-x11"
+MAIN="https://grimler.se/termux/termux-main"
+ROOT="https://grimler.se/termux/termux-root"
+X11="https://grimler.se/termux/termux-x11"

--- a/mirrors/europe/grimler.se
+++ b/mirrors/europe/grimler.se
@@ -1,6 +1,0 @@
-# This file is sourced by pkg
-# Mirror by grimler, hosted in the Netherlands
-WEIGHT=4
-MAIN="https://grimler.se/termux/termux-main"
-ROOT="https://grimler.se/termux/termux-root"
-X11="https://grimler.se/termux/termux-x11"

--- a/mirrors/north_america/packages.termux.dev
+++ b/mirrors/north_america/packages.termux.dev
@@ -1,6 +1,0 @@
-# This file is sourced by pkg
-# Main fosshost repo, hosted in Utah, US
-WEIGHT=4
-MAIN="https://packages.termux.dev/apt/termux-main"
-ROOT="https://packages.termux.dev/apt/termux-root"
-X11="https://packages.termux.dev/apt/termux-x11"

--- a/scripts/termux-change-repo.in
+++ b/scripts/termux-change-repo.in
@@ -95,12 +95,9 @@ select_individual_mirror() {
 
     # Choose default mirror per default
     MIRRORS=("$(get_mirror_url "${MIRROR_BASE_DIR}/default")" "$(get_mirror_description "${MIRROR_BASE_DIR}/default")" "on")
-    # Special handling of packages.termux.dev mirror to put it on top:
-    MIRRORS+=("$(get_mirror_url "${MIRROR_BASE_DIR}/north_america/packages.termux.dev")" "$(get_mirror_description "${MIRROR_BASE_DIR}/north_america/packages.termux.dev")" "off")
+
     for mirror in ${mirrors[@]}; do
-        if [ "$mirror" != "packages.termux.dev" ]; then
-            MIRRORS+=("$(get_mirror_url "$mirror")" "$(get_mirror_description "$mirror")" "off")
-        fi
+        MIRRORS+=("$(get_mirror_url "$mirror")" "$(get_mirror_description "$mirror")" "off")
     done
 
     local TEMPFILE="$(mktemp @TERMUX_PREFIX@/tmp/mirror.XXXXXX)"


### PR DESCRIPTION
Replace mirrors/default with grimler.se mirror for now.

This is done since Fosshost will unfortunately decommission its service on 28th of August.