### PR TITLE
Change cdn.lumito.net mirror from UK to Germany

### DIFF
--- a/mirrors/europe/cdn.lumito.net
+++ b/mirrors/europe/cdn.lumito.net
@@ -1,5 +1,5 @@
 # This file is sourced by pkg
-# Mirror by Lumito, hosted in the UK
+# Mirror by Lumito, hosted in Germany
 WEIGHT=1
 MAIN="https://cdn.lumito.net/termux/termux-main"
 ROOT="https://cdn.lumito.net/termux/termux-root"


### PR DESCRIPTION
I've changed my mirror ([cdn.lumito.net](https://cdn.lumito.net)) server location from UK to Germany, so I've updated the mirror file here.