### PR TITLE
scripts: remove mount and umount wrappers

### DIFF
--- a/scripts/Makefile.am
+++ b/scripts/Makefile.am
@@ -24,8 +24,7 @@ termux-setup-package-manager termux-setup-storage termux-wake-lock	\
 termux-wake-unlock
 
 # wrappers around tools in /system/bin:
-bin_SCRIPTS += df getprop logcat mount ping ping6 pm settings top	\
-umount cmd
+bin_SCRIPTS += cmd df getprop logcat ping ping6 pm settings top
 
 CLEANFILES = $(bin_SCRIPTS)
 


### PR DESCRIPTION
Android's variants do not seem to be able to handle logical volumes, so remove our wrappers in favour of the full tools from util-linux.
