### PR TITLE
Change cdn.lumito.net mirror domain to termux.cdn.lumito.net

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -22,7 +22,7 @@ dnl  along with termux-tools.  If not, see
 dnl  <https://www.gnu.org/licenses/>.
 
 AC_PREREQ([2.69])
-AC_INIT([termux-tools], [1.29.2], [support@termux.dev])
+AC_INIT([termux-tools], [1.29.3], [support@termux.dev])
 
 AM_INIT_AUTOMAKE([foreign])
 

--- a/mirrors/europe/cdn.lumito.net
+++ b/mirrors/europe/cdn.lumito.net
@@ -1,6 +1,0 @@
-# This file is sourced by pkg
-# Mirror by Lumito, hosted in Germany
-WEIGHT=1
-MAIN="https://cdn.lumito.net/termux/termux-main"
-ROOT="https://cdn.lumito.net/termux/termux-root"
-X11="https://cdn.lumito.net/termux/termux-x11"

--- a/mirrors/europe/termux.cdn.lumito.net
+++ b/mirrors/europe/termux.cdn.lumito.net
@@ -1,0 +1,6 @@
+# This file is sourced by pkg
+# Mirror by Lumito, hosted in Germany
+WEIGHT=1
+MAIN="https://termux.cdn.lumito.net/termux-main"
+ROOT="https://termux.cdn.lumito.net/termux-root"
+X11="https://termux.cdn.lumito.net/termux-x11"


### PR DESCRIPTION
I will soon use cdn.lumito.net for CDN bucket storage, so I'm moving the termux mirror to a new domain.

I've also changed the version number from v1.29.2 to v1.29.3