### PR TITLE
mirrors: add mirror.csclub.uwaterloo.ca

### DIFF
--- a/mirrors/Makefile.am
+++ b/mirrors/Makefile.am
@@ -22,7 +22,7 @@ termux.astra.in.ua termux.3san.dev
 # Mirrors in North America
 pkgdata_NORTH_AMERICA_MIRRORS = packages.termux.dev			\
 plug-mirror.rcac.purdue.edu dl.kcubeterm.com mirrors.utermux.dev	\
-mirror.mwt.me mirror.vern.cc
+mirror.mwt.me mirror.vern.cc mirror.csclub.uwaterloo.ca
 
 # Mirrors in Russia
 pkgdata_RUSSIA_MIRRORS = mirror.mephi.ru mirror.surf

--- a/mirrors/north_america/mirror.csclub.uwaterloo.ca
+++ b/mirrors/north_america/mirror.csclub.uwaterloo.ca
@@ -1,0 +1,6 @@
+# This file is sourced by pkg
+# Mirror by Computer Science Club of the University of Waterloo
+WEIGHT=1
+MAIN="https://mirror.csclub.uwaterloo.ca/termux/termux-main"
+ROOT="https://mirror.csclub.uwaterloo.ca/termux/termux-root"
+X11="https://mirror.csclub.uwaterloo.ca/termux/termux-x11"


### PR DESCRIPTION
Support http, https, rsync, ipv4 and ipv6.

Mirror by Computer Science Club of the University of Waterloo.