### PR TITLE
New setting: draw-bold-text-with-bright-colors

### DIFF
--- a/termux.properties
+++ b/termux.properties
@@ -118,6 +118,11 @@
 ### Force black colors for drawer and dialogs
 # use-black-ui = true
 
+### Render bold text in bright colors [8,16) when the active color is [0,8).
+### This is legacy behavior used by terminals lacking bold fonts, such as the
+### Linux framebuffer.
+# draw-bold-text-with-bright-colors = false
+
 ###############
 # HW keyboard shortcuts
 ###############


### PR DESCRIPTION
The new setting is draw-bold-text-with-bright-colors, and it is disabled by default, as it always should have been. This is also the name Alacritty uses. Similarly, it is disabled by default.

See termux-app#3285