### PR TITLE
termux-change-repo: promote mirror.termux.dev

### DIFF
--- a/scripts/termux-change-repo.in
+++ b/scripts/termux-change-repo.in
@@ -102,9 +102,10 @@ select_individual_mirror() {
     MIRRORS=("$(get_mirror_url "${MIRROR_BASE_DIR}/default")" "$(get_mirror_description "${MIRROR_BASE_DIR}/default")" "on")
     # Special handling of packages.termux.dev mirror to put it on top:
     MIRRORS+=("$(get_mirror_url "${MIRROR_BASE_DIR}/europe/packages.termux.dev")" "$(get_mirror_description "${MIRROR_BASE_DIR}/europe/packages.termux.dev")" "off")
+    MIRRORS+=("$(get_mirror_url "${MIRROR_BASE_DIR}/europe/mirror.termux.dev")" "$(get_mirror_description "${MIRROR_BASE_DIR}/europe/mirror.termux.dev")" "off")
     for mirror in ${mirrors[@]}; do
         mirror_url=$(get_mirror_url "$mirror")
-        if [ "$mirror_url" == "packages.termux.dev" ]; then continue; fi
+        if [[ "$mirror_url" == *".termux.dev" ]]; then continue; fi
         MIRRORS+=("$mirror_url" "$(get_mirror_description "$mirror")" "off")
     done
 


### PR DESCRIPTION
I think should give more spotlight to mirror.termux.dev which is buried deep in the list.

My testing (depending on time):
Best case: it works flawlessly
Bad case: it needs 5 or more retries to get my packages updated (package not found in mirror, redirection to http #47)
Worst case: it fails to get the metadata (incorrect size etc)