### PR TITLE
mirrors: add mirror.sjtu.edu.cn

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -22,7 +22,7 @@ dnl  along with termux-tools.  If not, see
 dnl  <https://www.gnu.org/licenses/>.
 
 AC_PREREQ([2.69])
-AC_INIT([termux-tools], [1.38.2], [support@termux.dev])
+AC_INIT([termux-tools], [1.38.3], [support@termux.dev])
 
 AM_INIT_AUTOMAKE([foreign])
 

--- a/mirrors/Makefile.am
+++ b/mirrors/Makefile.am
@@ -13,7 +13,7 @@ mirrors.ustc.edu.cn mirrors.hit.edu.cn mirrors.bfsu.edu.cn	\
 mirrors.aliyun.com mirrors.cqupt.edu.cn mirrors.dgut.edu.cn	\
 mirror.nyist.edu.cn mirrors.njupt.edu.cn mirrors.sau.edu.cn	\
 mirrors.scau.edu.cn mirrors.sdu.edu.cn mirrors.sustech.edu.cn   \
-mirrors.zju.edu.cn
+mirrors.zju.edu.cn mirror.sjtu.edu.cn
 
 # Mirrors in Europe
 pkgdata_EUROPE_MIRRORS = grimler.se mirror.termux.dev			\

--- a/mirrors/china/mirror.sjtu.edu.cn
+++ b/mirrors/china/mirror.sjtu.edu.cn
@@ -1,0 +1,6 @@
+# This file is sourced by pkg
+# Mirror by SJTUG, Shanghai Jiao Tong University
+WEIGHT=1
+MAIN="https://mirror.sjtu.edu.cn/termux/termux-main/"
+ROOT="https://mirror.sjtu.edu.cn/termux/termux-root/"
+X11="https://mirror.sjtu.edu.cn/termux/termux-x11/"


### PR DESCRIPTION
Mirrors by [SJTUG](https://mirror.sjtu.edu.cn)

Hosted in Shanghai, China. Updated once per 2 hours, 1Gb/s with IPv4/IPv6 support.

Repository | sources.list entry
-- | --
Main | deb https://mirror.sjtu.edu.cn/termux/termux-main stable main
Root | deb https://mirror.sjtu.edu.cn/termux/termux-root root stable
X11 | deb https://mirror.sjtu.edu.cn/termux/termux-x11 x11 main