### PR TITLE
termux-tools: Add /debug_ramdisk to PATH

### DIFF
--- a/scripts/su.in
+++ b/scripts/su.in
@@ -2,11 +2,11 @@
 
 unset LD_LIBRARY_PATH LD_PRELOAD
 
-for p in /sbin/su /system/sbin/su /system/bin/su /system/xbin/su /su/bin/su /magisk/.core/bin/su
+for p in /debug_ramdisk/su sbin/su /system/sbin/su /system/bin/su /system/xbin/su /su/bin/su /magisk/.core/bin/su
 do
 	if [ -x $p ]; then
 		# The su tool may require programs in PATH:
-		PATH=/sbin:/sbin/su:/su/bin:/su/xbin:/system/bin:/system/xbin \
+		PATH=/debug_ramdisk:/sbin:/sbin/su:/su/bin:/su/xbin:/system/bin:/system/xbin \
 			exec $p "$@"
 	fi
 done


### PR DESCRIPTION
Magisk now uses `/sbin` or `/debug_ramdisk` for tmpfs
Add `/debug_ramdisk` to `PATH` so that magisk `su` can be executed even it's not magic mounted to `/system/bin`