### PR TITLE
mirrors: update chinese mainland mirrors

### DIFF
--- a/mirrors/china/mirrors.aliyun.com
+++ b/mirrors/china/mirrors.aliyun.com
@@ -3,4 +3,4 @@
 WEIGHT=1
 MAIN="https://mirrors.aliyun.com/termux/termux-main"
 ROOT="https://mirrors.aliyun.com/termux/termux-root"
-X11="https://mirrors.aliyun.com/termux/x11-packages"
+X11="https://mirrors.aliyun.com/termux/termux-x11"

--- a/mirrors/china/mirrors.cqupt.edu.cn
+++ b/mirrors/china/mirrors.cqupt.edu.cn
@@ -1,6 +1,6 @@
 # This file is sourced by pkg
 # Mirror by CQUPT - Chongqing University of Posts and Telecommunications
 WEIGHT=1
-MAIN="https://mirrors.cqupt.edu.cn/termux/apt/termux-main"
-ROOT="https://mirrors.cqupt.edu.cn/termux/apt/termux-root"
-X11="https://mirrors.cqupt.edu.cn/termux/apt/termux-x11"
+MAIN="https://mirrors.cqupt.edu.cn/termux/termux-main"
+ROOT="https://mirrors.cqupt.edu.cn/termux/termux-root"
+X11="https://mirrors.cqupt.edu.cn/termux/termux-x11"

--- a/mirrors/china/mirrors.dgut.edu.cn
+++ b/mirrors/china/mirrors.dgut.edu.cn
@@ -1,6 +1,0 @@
-# This file is sourced by pkg
-# Mirror by Dongguan University of Technology
-WEIGHT=1
-MAIN="https://mirrors.dgut.edu.cn/termux/apt/termux-main"
-ROOT="https://mirrors.dgut.edu.cn/termux/apt/termux-root"
-X11="https://mirrors.dgut.edu.cn/termux/apt/termux-x11"

--- a/mirrors/china/mirrors.hit.edu.cn
+++ b/mirrors/china/mirrors.hit.edu.cn
@@ -1,6 +1,0 @@
-# This file is sourced by pkg
-# Mirror by Harbin Institute of Technology
-WEIGHT=1
-MAIN="https://mirrors.hit.edu.cn/termux/apt/termux-main"
-ROOT="https://mirrors.hit.edu.cn/termux/apt/termux-root"
-X11="https://mirrors.hit.edu.cn/termux/apt/termux-x11"

--- a/mirrors/china/mirrors.njupt.edu.cn
+++ b/mirrors/china/mirrors.njupt.edu.cn
@@ -1,6 +1,0 @@
-# This file is sourced by pkg
-# Mirror by Nanjing University of Posts and Telecommunications
-WEIGHT=1
-MAIN="https://mirrors.njupt.edu.cn/termux/apt/termux-main"
-ROOT="https://mirrors.njupt.edu.cn/termux/apt/termux-root"
-X11="https://mirrors.njupt.edu.cn/termux/apt/termux-x11"

--- a/mirrors/china/mirrors.scau.edu.cn
+++ b/mirrors/china/mirrors.scau.edu.cn
@@ -1,6 +1,0 @@
-# This file is sourced by pkg
-# Mirror by South China Agricultural University
-WEIGHT=1
-MAIN="https://mirrors.scau.edu.cn/termux/apt/termux-main"
-ROOT="https://mirrors.scau.edu.cn/termux/apt/termux-root"
-X11="https://mirrors.scau.edu.cn/termux/apt/termux-x11"

--- a/mirrors/china/mirrors.ustc.edu.cn
+++ b/mirrors/china/mirrors.ustc.edu.cn
@@ -1,6 +1,6 @@
 # This file is sourced by pkg
 # Mirror by University of Science and Technology of China
 WEIGHT=1
-MAIN="https://mirrors.ustc.edu.cn/termux/apt/termux-main"
-ROOT="https://mirrors.ustc.edu.cn/termux/apt/termux-root"
-X11="https://mirrors.ustc.edu.cn/termux/apt/termux-x11"
+MAIN="https://mirrors.ustc.edu.cn/termux/termux-main"
+ROOT="https://mirrors.ustc.edu.cn/termux/termux-root"
+X11="https://mirrors.ustc.edu.cn/termux/termux-x11"


### PR DESCRIPTION
`mirrors.aliyun.com`: fix x11 repo link

`mirrors.cqupt.edu.cn`: reducing redirects
`mirrors.ustc.edu.cn:` reducing redirects

`mirrors.dgut.edu.cn`: removed as unavailable
`mirrors.hit.edu.cn`: removed as unavailable
`mirrors.njupt.edu.cn`: removed as unavailable
`mirrors.scau.edu.cn`: removed as unavailable