### PR TITLE
replace PCRE2 with ERE

### DIFF
--- a/scripts/pkg.in
+++ b/scripts/pkg.in
@@ -160,7 +160,7 @@ get_mirror_weight() {
 
 select_mirror() {
 	local current_mirror
-	current_mirror=$(grep -oP 'https?://[^\s]+' <(grep -m 1 -P "^\s*deb\s+" @TERMUX_PREFIX@/etc/apt/sources.list) || true)
+	current_mirror=$(grep -oE 'https?://[^ ]+' <(grep -m 1 -E '^[[:space:]]*deb[[:space:]]+' @TERMUX_PREFIX@/etc/apt/sources.list) || true)
 
 	# Do not update mirror if $TERMUX_PKG_NO_MIRROR_SELECT was set.
 	if [ -n "${TERMUX_PKG_NO_MIRROR_SELECT-}" ] && [ -n "$current_mirror" ]; then

--- a/scripts/termux-info.in
+++ b/scripts/termux-info.in
@@ -45,7 +45,7 @@ updates() {
 
 repo_subscriptions_apt() {
 	local main_sources
-	main_sources=$(grep -P '^\s*deb\s' "@TERMUX_PREFIX@/etc/apt/sources.list")
+	main_sources=$(grep -E '^[[:space:]]*deb[[:space:]]' "@TERMUX_PREFIX@/etc/apt/sources.list")
 
 	if [ -n "$main_sources" ]; then
 		echo "# sources.list"
@@ -56,7 +56,7 @@ repo_subscriptions_apt() {
 		local filename repo_package supl_sources
 		while read -r filename; do
 			repo_package=$(dpkg -S "$filename" 2>/dev/null | cut -d : -f 1)
-			supl_sources=$(grep -P '^\s*deb\s' "$filename")
+			supl_sources=$(grep -E '^[[:space:]]*deb[[:space:]]' "$filename")
 
 			if [ -n "$supl_sources" ]; then
 				if [ -n "$repo_package" ]; then


### PR DESCRIPTION
This commit renders pkg and termux-info usable with busybox grep which does not support PCRE2, thus improving portability.