### PR TITLE
termux.properties: add missing config keys

### DIFF
--- a/termux.properties
+++ b/termux.properties
@@ -178,3 +178,13 @@
 
 ### ctrl+space (for marking text in emacs) does not work on some devices
 # ctrl-space-workaround = true
+
+###############
+# Terminal Margin adjustments
+###############
+
+### Horizontal (left/right) Margin
+# terminal-margin-horizontal=3
+
+### Vertical (top/bottom) Margin
+# terminal-margin-vertical=0


### PR DESCRIPTION
This patch adds the missing configuration keys in the `~/.termux/termux.properties` file related to adjusting the terminal margins. [WIKI Reference](https://wiki.termux.com/wiki/Terminal_Settings#Adjust_Terminal_Margin/Padding)