### PR TITLE
add termux-logout termux-title wall

### DIFF
--- a/doc/termux.1.md.in
+++ b/doc/termux.1.md.in
@@ -844,6 +844,23 @@ values.
     As Termux does not support locales, changing this variable is not
     recommended and may have unexpected effects.
 
+TOOLS
+=====
+
+Tools bundled with termux-tools
+
+`termux-logout`
+:   Run cleanup commands when executed from last remaining Termux session. Intended to be run from
+
+    ~/.bash_logout
+    termux-logout
+
+`termux-title`
+:   Update Termux tab titles similar to tmux. Run with termux-services package from
+
+    $SVDIR/title/run
+    exec termux-title
+
 FILES
 =====
 

--- a/scripts/Makefile.am
+++ b/scripts/Makefile.am
@@ -18,10 +18,10 @@
 
 # shell scripts:
 bin_SCRIPTS = chsh dalvikvm login pkg su termux-backup			\
-termux-change-repo termux-fix-shebang termux-info termux-open		\
+termux-change-repo termux-fix-shebang termux-info termux-logout termux-open		\
 termux-open-url termux-reload-settings termux-reset termux-restore	\
-termux-setup-package-manager termux-setup-storage termux-wake-lock	\
-termux-wake-unlock
+termux-setup-package-manager termux-setup-storage termux-title termux-wake-lock	\
+termux-wake-unlock wall
 
 # wrappers around tools in /system/bin:
 bin_SCRIPTS += df getprop logcat ping ping6 pm settings top

--- a/scripts/termux-logout.in
+++ b/scripts/termux-logout.in
@@ -1,0 +1,22 @@
+#!/bin/bash
+# todo source from @TERMUX_PREFIX@/bin/logout
+# help
+if [ -n "$1" ]; then
+	echo run this file from \~/.bash_logout to perform exit cleanup from last session
+	exit 0
+fi
+
+pp=$(pidof com.termux)
+pids=$(ps --ppid $pp -o pid=)
+s=$(echo $pids|wc|tr -s " "|cut -f3 -d" ")
+# exit silently if not final session
+if [ $s -ne 1 ]; then	exit 0; fi
+
+echo leaving final active session running cleanup
+service-daemon stop
+termux-api-stop
+
+# place custom commands here
+# start-stop-daemon --stop --pidfile $HOME/earlyoom.pid --remove-pidfile -v
+
+read -p "press enter to exit"

--- a/scripts/termux-title.in
+++ b/scripts/termux-title.in
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# help
+if [ -n "$1" ]; then
+	echo run this file from \$SVDIR/title/run to update session titles
+	exit
+fi
+
+# enable logging
+# exec >>$HOME/title
+exec >/dev/null
+
+pp=$(pidof com.termux)
+
+function titles(){
+	date
+for p in $(ps --ppid $pp -o pid=); do
+	cp=$(ps --ppid $p -o pid=|head -1)
+	tty=$(ps -p $p -o tty=|cut -f2 -d/)
+	if [ -n "$cp" ]; then
+		cmd=$(ps -p $cp -o cmd=|sed s,:,,|sed s,$HOME,~,)
+	fi
+	wd=$(pwdx $p|cut -f2 -d" "|sed s,$HOME,~,)
+	echo $tty $cp $wd $cmd
+	if [[ -n "$cp" ]]; then 
+		echo -ne "\e]0;$cmd\a" > /dev/pts/$tty
+	else
+		echo -ne "\e]0;$wd\a" > /dev/pts/$tty
+	fi	 
+done
+}
+
+while(true); do
+	titles
+	sleep 10
+done

--- a/scripts/wall.in
+++ b/scripts/wall.in
@@ -1,0 +1,23 @@
+#!/bin/sh
+function show_usage() {
+	echo usage: "wall <message>"
+	echo broadcast message to running sessions
+	exit 0
+}
+
+if [ $# -lt 1 ]; then
+	echo no message given
+	show_usage
+	exit 1
+fi
+
+case "$1" in
+	-\?|-h|--help|--usage)
+		show_usage;;
+esac
+
+pp=$(pidof com.termux)
+for p in $(ps --ppid $pp -o pid=); do
+  tty=$(ps -p $p -o tty=|cut -f2 -d/)
+  echo $@ > /dev/pts/$tty
+done


### PR DESCRIPTION
https://github.com/john-peterson/termux-tools/pull/new/wall

 add termux-logout termux-title wall

# termux-logout

this should cleanup on last session log out before TermuxService ends 

~~~
~/.bash_logout
termux-logout
~~~

# termux-title

run from

~~~
$SVDIR/title/run
#!/data/data/com.termux/files/usr/bin/sh
exec termux-title
~~~

or

~~~
~/.bash_login
start-stop-daemon --start --background --pidfile $HOME/title.pid -m -v --exec $PREFIX/bin/bash -- $PREFIX/bin/termux-title

~/.bash_logout
start-stop-daemon --stop --pidfile $HOME/title.pid --remove-pidfile -v
~~~


## scroll down bug

this is currently broken so that every title update scroll down in the active terminal 

i will submit a patch that disable scroll down for /dev/pts writes so that the terminal operator is the only scroller

it will be posted to

https://github.com/john-peterson/termux-app/commits/pts


# wall

 earlyoom use wall to broadcast memory maintenance 

https://github.com/john-peterson/termux-packages/commits/earlyoom

~~~
$PREFIX/bin/earlyoom-wall
#!/bin/sh
wall $EARLYOOM_NAME was killed by earlyoom
~~~


