### PR TITLE
Added Auto-prepend https:// to URLs without scheme in termux-open-url

### DIFF
--- a/scripts/termux-open-url.in
+++ b/scripts/termux-open-url.in
@@ -8,10 +8,10 @@ fi
 
 case "${TERMUX__USER_ID:-}" in ''|*[!0-9]*|0[0-9]*) TERMUX__USER_ID=0;; esac
 # Check for https & http
-if echo "$1" | grep -qE '^(http|https)://'; then
-    URL="$1"
-else
-    URL="https://$1"
-fi
+# Check for https & http
+case "$1" in
+    http://*|https://*) URL="$1" ;;
+    *) URL="https://$1" ;;
+esac
 
 am start --user "$TERMUX__USER_ID" -a android.intent.action.VIEW -d "$@" > /dev/null

--- a/scripts/termux-open-url.in
+++ b/scripts/termux-open-url.in
@@ -7,5 +7,11 @@ if [ $# != 1 ] && [ $# != 2 ]; then
 fi
 
 case "${TERMUX__USER_ID:-}" in ''|*[!0-9]*|0[0-9]*) TERMUX__USER_ID=0;; esac
+# Check for https & http
+if echo "$1" | grep -qE '^(http|https)://'; then
+    URL="$1"
+else
+    URL="https://$1"
+fi
 
 am start --user "$TERMUX__USER_ID" -a android.intent.action.VIEW -d "$@" > /dev/null


### PR DESCRIPTION
In this PR I have added script for  the `https:// `scheme to URLs that do not already include a scheme.I have specifically added support for **https://** as it is more secure compared to **http://**. Since security is a priority, I chose to default to https:// to ensure that URLs are opened over a secure connection whenever possible. `http://` support has not been added for this reason. We can add later too.

**Before the Change:**
If a user tried to open a URL like ` google.com` without specifying the scheme, the script would fail, and the user would not be able to visit the link.

![before](https://github.com/user-attachments/assets/fc96bbf6-6c53-47f3-ae5e-702768e94dee)


**After the Change:**
Now, if a user provides a URL without a scheme (e.g., google.com), the script automatically adds  `https:// `to the URL, redirecting user from a browser.

![after](https://github.com/user-attachments/assets/f5e78086-efef-46e4-af9b-308777feea77)



