### PR TITLE
Getting `termux-tools` ready for `apt` 3.0.0

### DIFF
--- a/scripts/pkg.in
+++ b/scripts/pkg.in
@@ -8,6 +8,7 @@ if [[ "$(id -u)" == "0" ]]; then
 fi
 
 # Setup TERMUX_APP_PACKAGE_MANAGER
+# shellcheck source=/dev/null
 source "@TERMUX_PREFIX@/bin/termux-setup-package-manager" || exit 1
 
 MIRROR_BASE_DIR="@TERMUX_PREFIX@/etc/termux/mirrors"
@@ -108,14 +109,22 @@ last_modified() {
 	echo $((now - mtime))
 }
 
+sed_escape_replacement() {
+	local r="$1"
+	r="${r//[\\]/\\\\}" # Escape `\`.
+	r="${r//[\/]/\\\/}" # Escape `/`.
+	r="${r//[&]/\\\&}"  # Escape `&`.
+	echo "$r"
+}
+
 has_repo() {
 	# Check if root-repo or x11-repo are installed
 	repo="$1"
 
-	if [ -f "@TERMUX_PREFIX@/etc/apt/sources.list.d/$repo.list" ]; then
-		echo true
-	else
-		echo false
+	if [[ -f "@TERMUX_PREFIX@/etc/apt/sources.list.d/$repo.sources" ]]; then
+		echo deb822
+	elif [[ -f "@TERMUX_PREFIX@/etc/apt/sources.list.d/$repo.list" ]]; then
+		echo legacy
 	fi
 }
 
@@ -132,6 +141,7 @@ get_mirror_url() {
 	local -r _has_repo_root="$3"
 
 	unset_mirror_variables
+	# shellcheck source=/dev/null
 	source "$_mirror"
 
 	if [[ -z "${MAIN:-}" ]]; then
@@ -178,7 +188,11 @@ get_mirror_weight() {
 
 select_mirror() {
 	local current_mirror
-	current_mirror=$(grep -oE 'https?://[^ ]+' <(grep -m 1 -E '^[[:space:]]*deb[[:space:]]+' @TERMUX_PREFIX@/etc/apt/sources.list) || true)
+	if [ -f "@TERMUX_PREFIX@/etc/apt/sources.list.d/main.sources" ]; then
+		current_mirror=$(grep -oE 'https?://[^ ]+' <(grep -m 1 -E '^[[:space:]]*URIs:[[:space:]]+' "@TERMUX_PREFIX@/etc/apt/sources.list.d/main.sources") || :)
+	elif [ -f "@TERMUX_PREFIX@/etc/apt/sources.list" ]; then
+		current_mirror=$(grep -oE 'https?://[^ ]+' <(grep -m 1 -E '^[[:space:]]*deb[[:space:]]+' "@TERMUX_PREFIX@/etc/apt/sources.list") || :)
+	fi
 
 	# Do not update mirror if $TERMUX_PKG_NO_MIRROR_SELECT was set.
 	if [ -n "${TERMUX_PKG_NO_MIRROR_SELECT-}" ] && [ -n "$current_mirror" ]; then
@@ -189,14 +203,14 @@ select_mirror() {
 
 	if [ -d "@TERMUX_PREFIX@/etc/termux/chosen_mirrors" ]; then
 		# Mirror group selected
-		mirrors=($(find @TERMUX_PREFIX@/etc/termux/chosen_mirrors/ -type f ! -name "*\.dpkg-old" ! -name "*\.dpkg-new" ! -name "*~"))
+		mirrors=($(find "@TERMUX_PREFIX@/etc/termux/chosen_mirrors/" -type f ! -name "*\.dpkg-old" ! -name "*\.dpkg-new" ! -name "*~"))
 	elif [ -f "@TERMUX_PREFIX@/etc/termux/chosen_mirrors" ]; then
 		# Single mirror selected
-		mirrors=("$(realpath @TERMUX_PREFIX@/etc/termux/chosen_mirrors)")
+		mirrors=("$(realpath "@TERMUX_PREFIX@/etc/termux/chosen_mirrors")")
 	elif [ -L "@TERMUX_PREFIX@/etc/termux/chosen_mirrors" ]; then
 		# Broken symlink, use all mirrors
 		mirrors=("${MIRROR_BASE_DIR}/default")
-		mirrors+=($(find ${MIRROR_BASE_DIR}/{asia,chinese_mainland,europe,north_america,oceania,russia}/ -type f ! -name "*\.dpkg-old" ! -name "*\.dpkg-new" ! -name "*~"))
+		mirrors+=($(find "${MIRROR_BASE_DIR}"/{asia,chinese_mainland,europe,north_america,oceania,russia}/ -type f ! -name "*\.dpkg-old" ! -name "*\.dpkg-new" ! -name "*~"))
 	else
 		echo "No mirror or mirror group selected. You might want to select one by running 'termux-change-repo'"
 		mirrors=("${MIRROR_BASE_DIR}/default")
@@ -339,29 +353,53 @@ select_mirror() {
 		selected_mirror="${weighted_mirrors[${random_weight}]}"
 	fi
 
-	if [ -n "$selected_mirror" ]; then
-		(
-			unset_mirror_variables
-			source "$selected_mirror"
-			echo "deb $MAIN stable main" > @TERMUX_PREFIX@/etc/apt/sources.list
-			if [[ "$has_repo_x11" == "true" ]]; then
-				echo "deb $X11 x11 main" > @TERMUX_PREFIX@/etc/apt/sources.list.d/x11.list
-			fi
-			if [[ "$has_repo_root" == "true" ]]; then
-				echo "deb $ROOT root stable" > @TERMUX_PREFIX@/etc/apt/sources.list.d/root.list
-			fi
-		)
-	else
+	if [ -z "$selected_mirror" ]; then
 		# Should not happen unless there is some issue with
 		# the script, or the mirror files
 		echo "Error: None of the mirrors are accessible"
 		exit 1
 	fi
+
+	(
+		unset_mirror_variables
+		# shellcheck source=/dev/null
+		source "$selected_mirror"
+
+		case "$(has_repo main)" in
+			'deb822')
+				sed -i -e "s|URIs:.*|$(sed_escape_replacement "URIs: $MAIN")|" \
+				"@TERMUX_PREFIX@/etc/apt/sources.list.d/main.sources"
+			;;
+			# There should always be a main repo, so fallback to
+			# creating sources.list if the `main.sources` file is missing
+			*) echo "deb $MAIN stable main" > "@TERMUX_PREFIX@/etc/apt/sources.list";;
+		esac
+
+		case "${has_repo_x11:-}" in
+			'deb822')
+				sed -i -e "s|URIs:.*|$(sed_escape_replacement "URIs: $X11")|" \
+				"@TERMUX_PREFIX@/etc/apt/sources.list.d/x11.sources"
+			;;
+			'legacy') echo "deb $X11 x11 main" > "@TERMUX_PREFIX@/etc/apt/sources.list.d/x11.list";;
+		esac
+
+		case "${has_repo_root:-}" in
+			'deb822')
+				sed -i -e "s|URIs:.*|$(sed_escape_replacement "URIs: $ROOT")|" \
+				"@TERMUX_PREFIX@/etc/apt/sources.list.d/root.sources"
+			;;
+			'legacy') echo "deb $ROOT root stable" > "@TERMUX_PREFIX@/etc/apt/sources.list.d/root.list";;
+		esac
+	)
 }
 
 update_apt_cache() {
 	local current_host
-	current_host=$(head -n 1 <(sed -nE -e 's|^\s*deb\s+https?://(.+)\s+stable\s+main$|\1|p' @TERMUX_PREFIX@/etc/apt/sources.list) || true)
+	if [ -f "@TERMUX_PREFIX@/etc/apt/sources.list.d/main.sources" ]; then
+		current_host=$(head -n 1 <(sed -nE 's|^\s*URIs:\s+https?://(.+)$|\1|p' "@TERMUX_PREFIX@/etc/apt/sources.list.d/main.sources") || :)
+	elif [ -f "@TERMUX_PREFIX@/etc/apt/sources.list" ]; then
+		current_host=$(head -n 1 <(sed -nE 's|^\s*deb\s+https?://(.+)\s+stable\s+main$|\1|p' "@TERMUX_PREFIX@/etc/apt/sources.list") || :)
+	fi
 
 	if [ -z "$current_host" ]; then
 		# No primary repositories configured?
@@ -385,7 +423,11 @@ update_apt_cache() {
 	cache_modified=$(last_modified "@TERMUX_CACHE_DIR@/apt/pkgcache.bin")
 
 	local sources_modified
-	sources_modified=$(last_modified "@TERMUX_PREFIX@/etc/apt/sources.list")
+	if [ -f "@TERMUX_PREFIX@/etc/apt/sources.list.d/main.sources" ]; then
+		sources_modified=$(last_modified "@TERMUX_PREFIX@/etc/apt/sources.list.d/main.sources")
+	elif [ -f "@TERMUX_PREFIX@/etc/apt/sources.list" ]; then
+		sources_modified=$(last_modified "@TERMUX_PREFIX@/etc/apt/sources.list")
+	fi
 
 	if (( sources_modified <= cache_modified )) || (( cache_modified > 1200 )); then
 		apt update
@@ -394,8 +436,8 @@ update_apt_cache() {
 
 force_check_mirror=false
 if [ "${1-}" = "--check-mirror" ]; then
-    force_check_mirror=true
-    shift 1
+	force_check_mirror=true
+	shift 1
 fi
 
 if [[ $# = 0 || $(echo "$1" | grep "^h") ]]; then
@@ -419,7 +461,7 @@ case "$TERMUX_APP_PACKAGE_MANAGER" in
 			rei*) apt install --reinstall "$@";;
 			se*) select_mirror; update_apt_cache; apt search "$@";;
 			un*|rem*|rm|del*) apt remove "$@";;
-                        upd*) select_mirror; apt update;;
+			upd*) select_mirror; apt update;;
 			up|upg*) select_mirror; apt update; apt full-upgrade "$@";;
 			*) ERROR=true;;
 		esac;;
@@ -435,7 +477,7 @@ case "$TERMUX_APP_PACKAGE_MANAGER" in
 			rei*) pacman -S "$@";;
 			se*) pacman -Sys "$@";;
 			un*|rem*|rm|del*) pacman -Rcns "$@";;
-                        upd*) pacman -Sy "$@";;
+			upd*) pacman -Sy "$@";;
 			up|upg*) pacman -Syu "$@";;
 			*) ERROR=true;;
 		esac;;

--- a/scripts/termux-info.in
+++ b/scripts/termux-info.in
@@ -44,30 +44,33 @@ updates() {
 }
 
 repo_subscriptions_apt() {
-	local main_sources
-	main_sources=$(grep -E '^[[:space:]]*deb[[:space:]]' "@TERMUX_PREFIX@/etc/apt/sources.list")
+	local apt_dir="@TERMUX_PREFIX@/etc/apt"
 
-	if [ -n "$main_sources" ]; then
-		echo "# sources.list"
-		echo "$main_sources"
-	fi
+	local filename source_entry repo_package sources_type
+	for filename in "${apt_dir}"/sources.list{,.d/*}; do
+		[[ -f "$filename" ]] || continue
+		case "$filename" in
+			*.sources) sources_type="deb822";;
+			*.list)    sources_type="legacy";;
+			*) continue;; # Not a valid source type, skip
+		esac
+		source_entry="$(<"$filename")"
+		repo_package=$(dpkg -S "$filename" 2>/dev/null | cut -d : -f 1)
 
-	if [ -d "@TERMUX_PREFIX@/etc/apt/sources.list.d" ]; then
-		local filename repo_package supl_sources
-		while read -r filename; do
-			repo_package=$(dpkg -S "$filename" 2>/dev/null | cut -d : -f 1)
-			supl_sources=$(grep -E '^[[:space:]]*deb[[:space:]]' "$filename")
+		local printf_format=""
+		if [[ -n "$repo_package" ]]; then
+			printf_format="# %s(%s) [%s]\n"
+		else
+			printf_format="# %s%s [%s]\n"
+		fi
 
-			if [ -n "$supl_sources" ]; then
-				if [ -n "$repo_package" ]; then
-					echo "# $repo_package (sources.list.d/$(basename "$filename"))"
-				else
-					echo "# sources.list.d/$(basename "$filename")"
-				fi
-				echo "$supl_sources"
-			fi
-		done < <(find "@TERMUX_PREFIX@/etc/apt/sources.list.d" -maxdepth 1 ! -type d)
-	fi
+		# shellcheck disable=SC2059
+		printf "${printf_format}" \
+			"${repo_package}" \
+			"${filename/$apt_dir\/}" \
+			"${sources_type}"
+		echo "$source_entry"
+	done
 }
 
 repo_subscriptions_pacman() {
@@ -86,6 +89,7 @@ repo_subscriptions_pacman() {
 }
 
 # Setup TERMUX_APP_PACKAGE_MANAGER
+# shellcheck source=/dev/null
 source "@TERMUX_PREFIX@/bin/termux-setup-package-manager" || exit 1
 
 case "${TERMUX__USER_ID:-}" in ''|*[!0-9]*|0[0-9]*) TERMUX__USER_ID=0;; esac
@@ -96,7 +100,7 @@ output=""
 if [ -n "${TERMUX_VERSION:-}" ]; then
 # Application version is exported in Termux v0.107 or higher only.
 output+="Termux Variables:
-$(compgen -e TERMUX_ | while read v; do echo "${v}=${!v}"; done)
+$(compgen -e TERMUX_ | while read -r v; do echo "${v}=${!v}"; done)
 "
 else
 output+="Termux Variables:
@@ -148,7 +152,7 @@ if [[ "$sdk_version" =~ ^[0-9]+$ ]] && [ "$sdk_version" -ge "26" ]; then
 fi
 TERMUX_PLUGINS="$(pm list packages --user "$TERMUX__USER_ID" $show_version_code 2>&1 </dev/null | grep -E "^package:$escaped_package_name\.[a-zA-Z]" | cut -d ":" -f 2- | grep -vE "^$escaped_package_name\.tapm\.[a-zA-Z]")"
 if [ -n "${TERMUX_PLUGINS:-}" ]; then
-	        output+="$(printf "\nInstalled termux plugins:\n${TERMUX_PLUGINS}\n")"
+	output+="$(printf "\nInstalled termux plugins:\n${TERMUX_PLUGINS}\n")"
 fi
 echo "$output"
 


### PR DESCRIPTION
- Part of termux/termux-packages#24212

Apt 3.0.0 makes the "multiline" `deb822` format the standard for package sources.
This PR aims to introduce support for this repo source format in `termux-tools`.

This initial commit only adds support in `pkg`.
I plan to add support in `termux-info` tomorrow, however that turned into half a refactor and I'm tired.

---

The changes to `pkg` introduce two possible return values from `has_repo`.
- `deb822`, the new standard format (determined by the `.sources` file extension)
- `legacy`, the old oneline format (determined by the `.list` file extension)
Support for the legacy oneline `.list` format isn't slated to be removed until 2029[^1],
so it is kept for backwards compatibility in the meantime.
- An empty return string (`""`) indicates that the repo is not present in either format.

I also fixed a couple shellcheck warnings and some indentation.
I may do a more extensive refactor of `pkg` as part of this PR later.

[^1]: https://man.archlinux.org/man/sources.list.5#ONE-LINE-STYLE_FORMAT