### PR TITLE
[RFC] `pkg`: never implicitly update package cache without upgrading all packages

### DIFF
--- a/scripts/pkg.in
+++ b/scripts/pkg.in
@@ -394,13 +394,19 @@ select_mirror() {
 }
 
 handle_install_apt() {
-	local install_log install_command
+	local install_log install_command pkgcache
 	# pipe the fd 3 to the current stdout,
 	# which will make anything printed to /dev/fd/3 print to the current shell's stdout
 	exec 3>&1
 	# attempt package installation without updating package cache
+	# only if it's not time for mirrors to be rotated
 	install_command="apt install $@"
-	if install_log="$(script -q -e -c "$install_command" /dev/null | tee /dev/fd/3)"; then
+	pkgcache="@TERMUX_CACHE_DIR@/apt/pkgcache.bin"
+	if [ ! -e "$pkgcache" ] || \
+		(( $(last_modified "$pkgcache") > 6 * 3600 )) || \
+		[ "$force_check_mirror" = "true" ]; then
+		install_log="Mirrors have not been rotated within the last 6 hours"
+	elif install_log="$(script -q -e -c "$install_command" /dev/null | tee /dev/fd/3)"; then
 		# close fd 3
 		exec 3>&-
 		# If the package installation was successful, then no further action is required
@@ -408,8 +414,13 @@ handle_install_apt() {
 	fi
 	# close fd 3
 	exec 3>&-
-	if ! grep -q -e 'Failed to fetch' -e 'Unable to locate package' <<< "$install_log"; then
+	if ! grep -q \
+		-e 'Failed to fetch' \
+		-e 'Unable to locate package' \
+		-e 'Mirrors have not been rotated within the last 6 hours' \
+		<<< "$install_log"; then
 		# if apt did not print "Failed to fetch" or "Unable to locate package",
+		# and mirrors have been rotated within the last 6 hours,
 		# then an error not handled here occurred, so exit.
 		# The original error message is still displayed to the user above.
 		exit 1


### PR DESCRIPTION
> [!IMPORTANT]
> These changes are not intended to be considered absolutely necessary or mandatory to merge.
> They are changes that would alter behavior users might have come to expect from Termux `pkg`, that has been different from how other distros behave for a long time.
> These changes are instead meant to serve an example of how Termux's `pkg` command **could** have been designed in retrospect, in order to prevent accidental partial upgrades, in a way that is familiar to users of other rolling-release distributions that existed for a long time before Termux existed.

- Fixes https://github.com/termux/termux-tools/issues/137

- Never skip updating the package cache based on a timeout or the presence of metadata files.
- Instead, always try directly installing packages first, then interpret the output message from the package manager to determine the appropriate action.
- If the package installation was successful despite the package cache not having been updated, then everything is actually OK, and no further action is required
- If the package installation failed with an error indicating failure to download the package **or** an error indicating the package was not found (which could happen in four cases: the package cache has never been generated, or the package is new and the package cache has not been updated since the package became available, or the package name has a typo and does not actually exist, or [most commonly] that the package is at a version in the local package cache that no longer exists at the same version on the mirror server due to the mirror server receiving a package bump, which would mean the package cache is genuinely outdated), then automatically update package cache **and** upgrade all packages, and **then** attempt to install the package again.
  - This change of behavior prevents the accidental partial upgrades that currently happen mainly because of the current `pkg install` command updating package cache without upgrading all packages simultaneously.
- If the package installation failed, but one of the errors handled here was not not detected in the output of the package manager, then exit and do nothing since in that case, there is no reason that updating the package cache or upgrading all packages would help.
- Do not implicitly update package cache during `pkg search` before running the package manager search command, because it could result in accidentally updating the package cache without upgrading all packages, which could result in accidental partial upgrades.


### What would change

- **`pkg install`** would no longer automatically rotate mirrors every time it has run if it has been more than 6 hours since the last mirror rotation. Instead, it would only rotate mirrors when **both** of the following conditions are met:
  - A package failed to download, and the reason is detected to be due to missing or outdated package cache
  - It has been more than 6 hours since the last mirror rotation

- **`pkg install`** would no longer automatically update the package cache every single time it is run. Instead, it would only update the package cache when the following condition is met:
  - A package failed to download, and the reason is detected to be due to missing or outdated package cache

- **`pkg install`** would no longer install package(s) immediately after updating the package cache, because that would perform a partial upgrade, which can sometimes cause `CANNOT LINK EXECUTABLE` errors, and other kinds of errors, to appear afterward.
  - Instead, it would either install package(s) successfully without updating the package cache (which is an acceptable situation if it succeeds),
  - or, if that fails, and the reason is detected to be due to a missing or outdated package cache, it would then:
    - update the package cache,
    - then interactively prompt for a full upgrade,
    - then interactively prompt to reattempt the installation of the package(s) that previously failed to download
  - If the package(s) failed to install due to any other reason, it is assumed that a problem has occurred that would not have any chance of being resolved by updating the package cache or performing a full upgrade (for example a package file conflict), and `pkg install` exits in a failure state, after showing the original error message.

- **`pkg search`** would no longer automatically update the package cache before searching for packages.
  - Instead, it would either search the existing package cache and display packages that could be found in the current package cache, which would be at the state it was the last time a package cache update was performed,
  - or, if no package cache has yet been downloaded (a clean installation of Termux), it would only show results from packages that are currently installed, and no results from available packages that are not installed.

### What wouldn't change

- **`pkg install`** would still always provide a pathway to installing packages successfully even if the package cache was missing or outdated at the moment that `pkg install` was initiated
- **`pkg update`** would still always perform only a package cache update, because that command is taken to mean an explicit, not an implicit, request to update the package cache.
- **`pkg upgrade`** would still keep the exact same behavior:
  - If the mirror has not been rotated for more than 6 hours, it would perform a mirror rotation,
  - then, it would update the package cache,
  - then, it would interactively prompt for a full upgrade
- All the behaviors described would remain consistent between **`pacman`-based** and **`apt`-based** Termux installations, meaning:
  - that all changes would take place for installations of both package manager types simultaneously,
  - and, since `pacman`-based Termux installations do not currently perform "mirror rotation", changes related to "mirror rotation" would not apply to `pacman`-based Termux installations.
  - All other changes would apply to `pacman`-based Termux installations, and all other changes are equally relevant to `pacman`-based and `apt`-based Termux installations.
  - This would preserve the current state of consistency between `pacman`-based and `apt`-based Termux installations, without increasing or reducing the degree of consistency between them.
- The behaviors of all other `pkg` subcommands not yet mentioned (`f*`, `sh*`, `autoc*`, `cl*`, `list-a*`, `list-i*`, `rei*`, `un*`) would remain exactly the same, and would not be affected by any of these changes.
- The behaviors of `apt` and `pacman` when invoked directly would remain exactly the same
  - The behaviors of `apt` and `pacman` when directly invoked are **essentially consistent, insofar as they relate to package cache synchronizing and package downloading, with their equivalent behaviors found in the GNU/Linux distros Debian sid and Arch Linux both prior to and after the creation of Termux**.
  - These changes would only affect the behavior of the `pkg` wrapper of `apt` and `pacman`, with the goal of removing `pkg`'s current tendency to perform **implicit package cache updates without upgrading all packages immediately afterward** (implicit partial upgrades)