### PR TITLE
mirrors: remove duplicate and incorrect mirror def for mirror.mwt.me

### DIFF
--- a/mirrors/Makefile.am
+++ b/mirrors/Makefile.am
@@ -71,6 +71,7 @@ china/mirrors.ustc.edu.cn \
 china/mirrors.zju.edu.cn \
 chinese_mainland/mirrors.qvq.net.cn \
 europe/cdn.lumito.net \
+europe/mirror.mwt.me \
 europe/mirror.polido.pt \
 europe/mirror.termux.dev \
 europe/mirror.termux.dv \

--- a/mirrors/europe/mirror.mwt.me
+++ b/mirrors/europe/mirror.mwt.me
@@ -1,6 +1,0 @@
-# This file is sourced by pkg
-# Mirror by Mwt. Hosted in Luxembourg.
-WEIGHT=1
-MAIN="https://mirror.mwt.me/termux/main"
-ROOT="https://mirror.mwt.me/termux/root"
-X11="https://mirror.mwt.me/termux/x11"


### PR DESCRIPTION
Noticed this while developing mirror monitoring - we claim the same
domain is served out of both New Jersey, US and Luxembourg.
mirror.mwt.me redirects to https://www.matthewthom.as/mirrors/, which
says everything is is Newark (which is in New Jersey).
