### PR TITLE
mirrors: remove mirror.bardia.tech (permanently down)

### DIFF
--- a/mirrors/Makefile.am
+++ b/mirrors/Makefile.am
@@ -49,6 +49,7 @@ pkgdata_RUSSIA_MIRRORS = mirror.mephi.ru repository.su
 # would otherwise be left as is after package upgrades and would still
 # get used during mirror selection.
 pkgdata_MIRRORS_REMOVED = \
+asia/mirrors.bardia.tech \
 asia/packages.nscdn.top \
 china/mirrors.dgut.edu.cn \
 china/mirrors.hit.edu.cn \

--- a/mirrors/asia/mirror.bardia.tech
+++ b/mirrors/asia/mirror.bardia.tech
@@ -1,6 +1,0 @@
-# This file is sourced by pkg
-# Mirror by Bardia Moshiri. Hosted in Iran.
-WEIGHT=1
-MAIN="https://mirror.bardia.tech/termux/termux-main"
-ROOT="https://mirror.bardia.tech/termux/termux-root"
-X11="https://mirror.bardia.tech/termux/termux-x11"


### PR DESCRIPTION
In this comment[0], its operator said they are unable to keep operating
it.

[0] https://github.com/termux/termux-tools/issues/170#issuecomment-2916525871
