### PR TITLE
mirrors: remove dl.kcubeterm.com (permanently down)

### DIFF
--- a/mirrors/Makefile.am
+++ b/mirrors/Makefile.am
@@ -31,7 +31,7 @@ nl.mirror.flokinet.net
 
 # Mirrors in North America
 pkgdata_NORTH_AMERICA_MIRRORS = plug-mirror.rcac.purdue.edu          \
-dl.kcubeterm.com mirrors.utermux.dev mirror.fcix.net mirror.mwt.me   \
+mirrors.utermux.dev mirror.fcix.net mirror.mwt.me   \
 mirror.vern.cc mirror.csclub.uwaterloo.ca mirror.quantum5.ca		 \
 termux.danyael.xyz gnlug.org
 
@@ -82,6 +82,7 @@ europe/mirror.termux.dev \
 europe/mirror.termux.dv \
 europe/termux.astra.in.ua \
 europe/termux.sahilister.in \
+north_america/dl.kcubeterm.com \
 north_america/packages.termux.dev \
 oceania/mirrors.wale.id.au \
 russia/mirror.surf \

--- a/mirrors/north_america/dl.kcubeterm.com
+++ b/mirrors/north_america/dl.kcubeterm.com
@@ -1,6 +1,0 @@
-# This file is sourced by pkg
-# Mirror by Kcubeterm, in California, US
-WEIGHT=1
-MAIN="https://dl.kcubeterm.com/termux-main"
-ROOT="https://dl.kcubeterm.com/termux-root"
-X11="https://dl.kcubeterm.com/termux-x11"


### PR DESCRIPTION
https://github.com/termux/termux-tools/issues/182#issuecomment-2969436225

Closes https://github.com/termux/termux-tools/issues/182
