### PR TITLE
pkg.in: Use shell variable expansion for comparison

### DIFF
--- a/scripts/pkg.in
+++ b/scripts/pkg.in
@@ -440,7 +440,7 @@ if [ "${1-}" = "--check-mirror" ]; then
 	shift 1
 fi
 
-if [[ $# = 0 || $(echo "$1" | grep "^h") ]]; then
+if [[ $# = 0 || "${1:0:1} == "h" ]]; then
 	show_help
 fi
 


### PR DESCRIPTION
avoids the overhead of spawning a subshell, piping grep, more standalone code etc..