### PR TITLE
Enable access to the “Android/data” or “Android/obb” folders in Android 11+ without root privileges.

### DIFF
--- a/termux.properties
+++ b/termux.properties
@@ -41,6 +41,9 @@
 ### extra keys functionality.
 # volume-keys = volume
 
+### Uncomment to enable access to the “Android/data” or “Android/obb” folders in Android 11+ without root privileges.
+# append-zero-width-space-to-symlink-shared = true
+
 ###############
 # Fullscreen mode
 ###############


### PR DESCRIPTION
Append 'Zero Width Space' to symlink shared (configurable).
Allows to access the “Android/data” or “Android/obb” folders in Android 11+ without root privileges.

In relation to [https://github.com/termux/termux-app/pull/4777](url)