### PR TITLE
mirrors: add easycli.sh

### DIFF
--- a/mirrors/Makefile.am
+++ b/mirrors/Makefile.am
@@ -27,7 +27,7 @@ md.mirrors.hacktegic.com ftp.fau.de is.mirror.flokinet.net		\
 ro.mirror.flokinet.net mirrors.medzik.dev	\
 mirror.sunred.org mirror.autkin.net mirror.bouwhuis.network		\
 mirror.leitecastro.com ftp.agdsn.de	ftp.icm.edu.pl		        \
-nl.mirror.flokinet.net mirror.cutie.dating
+nl.mirror.flokinet.net mirror.cutie.dating easycli.sh
 
 # Mirrors in North America
 pkgdata_NORTH_AMERICA_MIRRORS = plug-mirror.rcac.purdue.edu          \

--- a/mirrors/europe/easycli.sh
+++ b/mirrors/europe/easycli.sh
@@ -1,0 +1,6 @@
+# This file is sourced by pkg
+# Mirror by Sylirre. Hosted in Germany, backed by Cloudflare.
+WEIGHT=1
+MAIN="https://easycli.sh/termux/termux-main"
+ROOT="https://easycli.sh/termux/termux-root"
+X11="https://easycli.sh/termux/termux-x11"


### PR DESCRIPTION
My Termux mirror hosted side-by-side with rootfs files for proot-distro.

Backed by CloudFlare. Origin server placed in Frankfurt and has 512 mbps unmetered link.

Synchronized every 8 hours.