### PR TITLE
scripts: port alpine-conf's setup-proxy and setup-dns

### DIFF
--- a/scripts/Makefile.am
+++ b/scripts/Makefile.am
@@ -20,8 +20,8 @@
 bin_SCRIPTS = chsh dalvikvm login pkg su termux-backup			\
 termux-change-repo termux-fix-shebang termux-info termux-open		\
 termux-open-url termux-reload-settings termux-reset termux-restore	\
-termux-setup-package-manager termux-setup-storage termux-wake-lock	\
-termux-wake-unlock
+termux-setup-dns termux-setup-package-manager termux-setup-proxy	\
+termux-setup-storage termux-wake-lock termux-wake-unlock
 
 # wrappers around tools in /system/bin:
 bin_SCRIPTS += df getprop logcat ping ping6 pm settings top
@@ -75,7 +75,9 @@ $(eval $(call tool-rule,termux-open-url))
 $(eval $(call tool-rule,termux-reload-settings))
 $(eval $(call tool-rule,termux-reset))
 $(eval $(call tool-rule,termux-restore))
+$(eval $(call tool-rule,termux-setup-dns))
 $(eval $(call tool-rule,termux-setup-package-manager))
+$(eval $(call tool-rule,termux-setup-proxy))
 $(eval $(call tool-rule,termux-setup-storage))
 $(eval $(call tool-rule,termux-wake-lock))
 $(eval $(call tool-rule,termux-wake-unlock))

--- a/scripts/termux-setup-dns.in
+++ b/scripts/termux-setup-dns.in
@@ -1,0 +1,92 @@
+#!/bin/sh
+
+# This file is originally MIT licensed from Alpine Linux's alpine-conf package.
+# https://gitlab.alpinelinux.org/alpine/alpine-conf/-/blob/master/LICENSE
+# https://gitlab.alpinelinux.org/alpine/alpine-conf/-/blob/master/libalpine.sh.in
+# https://gitlab.alpinelinux.org/alpine/alpine-conf/-/blob/master/setup-dns.in
+
+_ask() {
+	local _redo=0
+
+	read -r resp
+	case "$resp" in
+	!)	echo "Type 'exit' to return to setup."
+		sh
+		_redo=1
+		;;
+	!*)	eval "${resp#?}"
+		_redo=1
+		;;
+	esac
+	return $_redo
+}
+
+ask() {
+	local _question="$1" _default="$2"
+
+	while :; do
+		printf %s "$_question "
+		[ -z "$_default" ] || printf "[%s] " "$_default"
+		_ask && : "${resp:=$_default}" && break
+	done
+}
+
+usage() {
+	cat <<-__EOF__
+		usage: termux-setup-dns [-h] [-d DOMAINNAME] [IPADDR...]
+
+		Setup $PREFIX/etc/resolv.conf DNS settings
+
+		options:
+		 -h  Show this help
+		 -d  specify search domain name
+
+		The optional IPADDR are a list of DNS servers to use.
+	__EOF__
+	exit "$1"
+}
+
+while getopts "d:n:h" opt; do
+	case $opt in
+		d) DOMAINNAME="$OPTARG";;
+		h) usage 0;;
+		n) NAMESERVERS="$OPTARG";;
+		'?') usage "1" >&2;;
+	esac
+done
+shift $(($OPTIND - 1))
+
+
+conf="$PREFIX/etc/resolv.conf"
+
+if [ -f "$conf" ] ; then
+	domain=$(awk '/^domain/ {print $2}' "$conf")
+	dns=$(awk '/^nameserver/ {printf "%s ",$2}' "$conf")
+fi
+
+if [ -n "$DOMAINNAME" ]; then
+	domain="$DOMAINNAME"
+elif [ $# -eq 0 ]; then
+	ask "DNS domain name? (e.g 'bar.com')" "$domain"
+	domain="$resp"
+fi
+
+if [ -n "$NAMESERVERS" ] || [ $# -gt 0 ];then
+	dns="$NAMESERVERS"
+else
+	ask "DNS nameserver(s)?" "${dns% }"
+	dns="$(echo "$resp" | tr ',' ' ')"
+fi
+
+if [ -n "$domain" ]; then
+	mkdir -p "${conf%/*}"
+	echo "search $domain" > "$conf"
+fi
+
+if [ -n "$dns" ] || [ $# -gt 0 ] && [ -f "$conf" ]; then
+	sed -i -e '/^nameserver/d' "$conf"
+fi
+for i in $dns "$@"; do
+	mkdir -p "${conf%/*}"
+	echo "nameserver $i" >> "$conf"
+done

--- a/scripts/termux-setup-proxy.in
+++ b/scripts/termux-setup-proxy.in
@@ -1,0 +1,97 @@
+#!/bin/sh
+
+# This file is originally MIT licensed from Alpine Linux's alpine-conf package.
+# https://gitlab.alpinelinux.org/alpine/alpine-conf/-/blob/master/LICENSE
+# https://gitlab.alpinelinux.org/alpine/alpine-conf/-/blob/master/libalpine.sh.in
+# https://gitlab.alpinelinux.org/alpine/alpine-conf/-/blob/master/setup-proxy.in
+
+_ask() {
+	local _redo=0
+
+	read -r resp
+	case "$resp" in
+	!)	echo "Type 'exit' to return to setup."
+		sh
+		_redo=1
+		;;
+	!*)	eval "${resp#?}"
+		_redo=1
+		;;
+	esac
+	return $_redo
+}
+
+ask() {
+	local _question="$1" _default="$2"
+
+	while :; do
+		printf %s "$_question "
+		[ -z "$_default" ] || printf "[%s] " "$_default"
+		_ask && : "${resp:=$_default}" && break
+	done
+}
+
+usage() {
+	cat <<-__EOF__
+		usage: termux-setup-proxy [-hq] [PROXYURL]
+
+		Setup http proxy
+
+		options:
+		 -h  Show this help
+		 -q  Quiet mode
+
+		If PROXYURL is not specified user will be prompted.
+	__EOF__
+	exit "$1"
+}
+
+while getopts "hp:q" opt; do
+	case "$opt" in
+		q) quiet=1;;
+		h) usage 0;;
+		p) PREFIX=$OPTARG;;
+		'?') usage "1" >&2;;
+	esac
+done
+shift $(( $OPTIND - 1))
+
+proxyurl="$1"
+
+PROFILE="$PREFIX/etc/profile.d/proxy.sh"
+
+if [ -f "$PROFILE" ] ; then
+	. "$PROFILE"
+fi
+
+suggest=${http_proxy:-none}
+while [ $# -eq 0 ]; do
+	case "$proxyurl" in
+		http://*|https://*) break;;
+		none) break;;
+	esac
+	ask "HTTP/FTP proxy URL? (e.g. 'http://proxy:8080', or 'none')" "$suggest"
+	proxyurl=$resp
+done
+
+if [ "$proxyurl" = "none" ]; then
+	rm -f "$PROFILE"
+else
+	mkdir -p "${PROFILE%/*}"
+	cat >"$PROFILE" <<-__EOF__
+		# this file was generated with and might get overwritten by setup-proxy
+
+		export http_proxy=$proxyurl
+		export https_proxy=$proxyurl
+		export ftp_proxy=$proxyurl
+		export no_proxy=localhost
+	__EOF__
+fi
+
+if [ -z "$quiet" ] && [ "$proxyurl" != "none" ]; then
+	cat <<-__EOF__
+
+		To make changes active please do login again or source $PROFILE
+		with ". $PROFILE"
+	__EOF__
+fi


### PR DESCRIPTION
I found it very useful for Termux, so I ported it. I removed some Alpinism things.
I also credited their works.

I tested it and it worked as intended.